### PR TITLE
Added the -Dwtpversion=2.0 property

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ File -> Import -> Maven -> Existing Maven projects
 ```
 2b) Alternatively, import as Eclipse projects
 ```
-mvn eclipse:eclipse
+mvn eclipse:eclipse -Dwtpversion=2.0
 File -> Import -> General -> Existing Projects Into Workspace


### PR DESCRIPTION
Added the -Dwtpversion=2.0 property in eclipse:eclipse command, as it is required to provide appropriate faceting. Otherwise you can not do Run On Server option in Eclipse ( or Spring STS )
